### PR TITLE
feat: added depth and stencil buffering

### DIFF
--- a/.agent/rules/main-rules.md
+++ b/.agent/rules/main-rules.md
@@ -1,0 +1,59 @@
+---
+trigger: always_on
+---
+
+# AI Guidelines for KhoraEngine
+
+> [!IMPORTANT]
+> **ALWAYS** consult these guidelines and the project documentation before making changes (voir @docs folder)
+> **ALWAYS** follow the principles defined in the documentation.
+> **ALWAYS** use the snippets provided in the `.vscode` directory to implement the changes.
+> **ALWAYS** consider that you are building things fro a real engine, and provide the most advanced and performant solutions.
+> **ALWAYS** finish a feature by adding tests.
+> **ALWAYS** use the `cargo xtask` commands to build, test, and check the code.
+
+## Documentation Resources
+
+- **Primary Source**: `docs/` directory (contains all project documentation).
+- **Narrative Documentation**: `docs/src/` (source for mdBook).
+- **Online Book**: [https://eraflo.github.io/KhoraEngine/](https://eraflo.github.io/KhoraEngine/)
+- **API Reference**: [https://eraflo.github.io/KhoraEngine/api/index.html](https://eraflo.github.io/KhoraEngine/api/index.html) (or generate locally via `cargo doc`).
+- **Contributing Guidelines**: `CONTRIBUTING.md`
+
+## Core Principles (SAA & CLAD)
+
+KhoraEngine is built on the **Symbiotic Adaptive Architecture (SAA)** implemented via the **CLAD Pattern**.
+
+### The 7 Pillars of SAA
+1.  **Dynamic Context Core (DCC)**: The central nervous system maintaining a situational model.
+2.  **Intelligent Subsystem Agents (ISAs)**: Semi-autonomous components (Rendering, Physics, etc.) that negotiate for resources.
+3.  **GORNA (Goal-Oriented Resource Negotiation & Allocation)**: The protocol for dynamic resource budgeting.
+4.  **Adaptive Game Data Flows (AGDF)**: Dynamic data layout via **CRPECS**.
+5.  **Semantic Interfaces & Contracts**: Formal Rust traits defining capabilities and requirements (`khora_core`).
+6.  **Observability & Traceability**: "Glass Box" philosophy; every decision must be logged with context.
+7.  **Developer Guidance**: The engine serves the developer (Learning, Stable, and Manual modes).
+
+### CLAD Implementation Mapping
+
+| SAA Concept | Crate | Responsibility |
+| :--- | :--- | :--- |
+| **DCC & GORNA** | `khora_control` | Strategic brain, budgeting. |
+| **ISAs** | `khora_agents` | Tactical managers. |
+| **Strategies** | `khora_lanes` | Fast, deterministic execution paths. |
+| **AGDF** | `khora_data` | Data layout, CRPECS. |
+| **Contracts** | `khora_core` | Universal traits/types. |
+| **Telemetry** | `khora_telemetry` | Observability. |
+| **Infra** | `khora_infra` | Hardware/OS bridge. |
+
+## Workflow Instructions
+
+1.  **Check Docs First**: Before implementing a feature or fix, verify if it aligns with the SAA/CLAD principles.
+2.  **Respect the Architecture**: Do not bypass the SAA (e.g., don't hardcode resource usage without negotiation unless in a specific "Lane" context).
+3.  **Update Docs**: If you change code, update the corresponding `mdBook` entry or rustdoc.
+
+## Quality Checks
+
+Before every commit, run:
+```bash
+cargo xtask all  # build, test, check, format, clippy
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "khora-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "khora-infra"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "khora-lanes"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/khora-core/Cargo.toml
+++ b/crates/khora-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khora-core"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Foundational crate with traits, core types, and interface contracts"
 

--- a/crates/khora-core/src/renderer/api/command.rs
+++ b/crates/khora-core/src/renderer/api/command.rs
@@ -64,6 +64,25 @@ pub struct RenderPassColorAttachment<'a> {
     pub ops: Operations<LinearRgba>,
 }
 
+/// A comprehensive description of a depth/stencil attachment for a render pass.
+///
+/// This struct describes how the depth and stencil aspects of a texture should be
+/// handled during a render pass. Both aspects are optional - if an aspect's operations
+/// are `None`, that aspect will be loaded from the texture and its contents preserved.
+#[derive(Debug)]
+pub struct RenderPassDepthStencilAttachment<'a> {
+    /// The [`TextureViewId`] for the depth/stencil texture.
+    /// This texture must have been created with a depth/stencil format
+    /// (e.g., `Depth32Float`, `Depth24PlusStencil8`).
+    pub view: &'a TextureViewId,
+    /// The load and store operations for the depth aspect.
+    /// If `None`, the depth aspect will be loaded and stored (read-only depth test).
+    pub depth_ops: Option<Operations<f32>>,
+    /// The load and store operations for the stencil aspect.
+    /// If `None`, the stencil aspect will be loaded and stored (read-only stencil test).
+    pub stencil_ops: Option<Operations<u32>>,
+}
+
 /// A descriptor for a render pass.
 ///
 /// This struct groups all the color and depth/stencil attachments that will be used
@@ -74,7 +93,9 @@ pub struct RenderPassDescriptor<'a> {
     pub label: Option<&'a str>,
     /// A slice of color attachments to be used in the pass.
     pub color_attachments: &'a [RenderPassColorAttachment<'a>],
-    // pub depth_stencil_attachment: Option<...>, // To be added in the future
+    /// An optional depth/stencil attachment for this pass.
+    /// When set, enables depth testing and/or stencil operations.
+    pub depth_stencil_attachment: Option<RenderPassDepthStencilAttachment<'a>>,
 }
 
 /// Describes a request to write a timestamp at specific points within a pass.
@@ -96,4 +117,100 @@ pub struct ComputePassDescriptor<'a> {
     pub label: Option<&'a str>,
     /// Optional timestamp recording requests for this pass, used for profiling.
     pub timestamp_writes: Option<PassTimestampWrites<'a>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::renderer::TextureViewId;
+
+    #[test]
+    fn test_load_op_variants() {
+        // Test Clear variant for color (LinearRgba)
+        let clear_color: LoadOp<LinearRgba> = LoadOp::Clear(LinearRgba::new(1.0, 0.5, 0.0, 1.0));
+        assert!(matches!(clear_color, LoadOp::Clear(_)));
+
+        // Test Load variant
+        let load: LoadOp<LinearRgba> = LoadOp::Load;
+        assert!(matches!(load, LoadOp::Load));
+
+        // Test Clear variant for depth (f32)
+        let clear_depth: LoadOp<f32> = LoadOp::Clear(1.0);
+        assert!(matches!(clear_depth, LoadOp::Clear(v) if (v - 1.0).abs() < f32::EPSILON));
+
+        // Test Clear variant for stencil (u32)
+        let clear_stencil: LoadOp<u32> = LoadOp::Clear(0);
+        assert!(matches!(clear_stencil, LoadOp::Clear(0)));
+    }
+
+    #[test]
+    fn test_store_op_variants() {
+        let store = StoreOp::Store;
+        let discard = StoreOp::Discard;
+
+        assert_eq!(store, StoreOp::Store);
+        assert_eq!(discard, StoreOp::Discard);
+        assert_ne!(store, discard);
+    }
+
+    #[test]
+    fn test_depth_stencil_attachment_creation() {
+        let view_id = TextureViewId(42);
+
+        let attachment = RenderPassDepthStencilAttachment {
+            view: &view_id,
+            depth_ops: Some(Operations {
+                load: LoadOp::Clear(1.0),
+                store: StoreOp::Store,
+            }),
+            stencil_ops: None,
+        };
+
+        assert_eq!(*attachment.view, TextureViewId(42));
+        assert!(attachment.depth_ops.is_some());
+        assert!(attachment.stencil_ops.is_none());
+    }
+
+    #[test]
+    fn test_render_pass_descriptor_with_depth() {
+        let view_id = TextureViewId(1);
+        let depth_view_id = TextureViewId(2);
+
+        let color_attachment = RenderPassColorAttachment {
+            view: &view_id,
+            resolve_target: None,
+            ops: Operations {
+                load: LoadOp::Clear(LinearRgba::new(0.0, 0.0, 0.0, 1.0)),
+                store: StoreOp::Store,
+            },
+        };
+
+        let depth_attachment = RenderPassDepthStencilAttachment {
+            view: &depth_view_id,
+            depth_ops: Some(Operations {
+                load: LoadOp::Clear(1.0),
+                store: StoreOp::Store,
+            }),
+            stencil_ops: None,
+        };
+
+        let descriptor = RenderPassDescriptor {
+            label: Some("Test Pass"),
+            color_attachments: std::slice::from_ref(&color_attachment),
+            depth_stencil_attachment: Some(depth_attachment),
+        };
+
+        assert_eq!(descriptor.label, Some("Test Pass"));
+        assert_eq!(descriptor.color_attachments.len(), 1);
+        assert!(descriptor.depth_stencil_attachment.is_some());
+    }
+
+    #[test]
+    fn test_render_pass_descriptor_default() {
+        let descriptor = RenderPassDescriptor::default();
+
+        assert!(descriptor.label.is_none());
+        assert!(descriptor.color_attachments.is_empty());
+        assert!(descriptor.depth_stencil_attachment.is_none());
+    }
 }

--- a/crates/khora-core/src/renderer/api/context.rs
+++ b/crates/khora-core/src/renderer/api/context.rs
@@ -20,6 +20,8 @@ use crate::{math::LinearRgba, renderer::api::TextureViewId};
 pub struct RenderContext<'a> {
     /// The texture view to render into (typically the swapchain).
     pub color_target: &'a TextureViewId,
+    /// The depth texture view for depth testing. If `None`, depth testing is disabled.
+    pub depth_target: Option<&'a TextureViewId>,
     /// The color to clear the framebuffer with.
     pub clear_color: LinearRgba,
 }
@@ -30,11 +32,46 @@ impl<'a> RenderContext<'a> {
     /// # Arguments
     ///
     /// * `color_target`: The texture view to render into
+    /// * `depth_target`: Optional depth texture view for depth testing
     /// * `clear_color`: The color to clear the framebuffer with
-    pub fn new(color_target: &'a TextureViewId, clear_color: LinearRgba) -> Self {
+    pub fn new(
+        color_target: &'a TextureViewId,
+        depth_target: Option<&'a TextureViewId>,
+        clear_color: LinearRgba,
+    ) -> Self {
         Self {
             color_target,
+            depth_target,
             clear_color,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_context_new_with_depth() {
+        let color_view = TextureViewId(1);
+        let depth_view = TextureViewId(2);
+        let clear_color = LinearRgba::new(0.1, 0.2, 0.3, 1.0);
+
+        let ctx = RenderContext::new(&color_view, Some(&depth_view), clear_color);
+
+        assert_eq!(*ctx.color_target, TextureViewId(1));
+        assert!(ctx.depth_target.is_some());
+        assert_eq!(*ctx.depth_target.unwrap(), TextureViewId(2));
+    }
+
+    #[test]
+    fn test_render_context_new_without_depth() {
+        let color_view = TextureViewId(1);
+        let clear_color = LinearRgba::new(0.0, 0.0, 0.0, 1.0);
+
+        let ctx = RenderContext::new(&color_view, None, clear_color);
+
+        assert_eq!(*ctx.color_target, TextureViewId(1));
+        assert!(ctx.depth_target.is_none());
     }
 }

--- a/crates/khora-infra/Cargo.toml
+++ b/crates/khora-infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khora-infra"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Concrete implementations of external dependencies"
 

--- a/crates/khora-infra/src/graphics/wgpu/conversions.rs
+++ b/crates/khora-infra/src/graphics/wgpu/conversions.rs
@@ -413,6 +413,24 @@ impl IntoWgpu<wgpu::LoadOp<wgpu::Color>> for LoadOp<LinearRgba> {
     }
 }
 
+impl IntoWgpu<wgpu::LoadOp<f32>> for LoadOp<f32> {
+    fn into_wgpu(self) -> wgpu::LoadOp<f32> {
+        match self {
+            LoadOp::Load => wgpu::LoadOp::Load,
+            LoadOp::Clear(depth) => wgpu::LoadOp::Clear(depth),
+        }
+    }
+}
+
+impl IntoWgpu<wgpu::LoadOp<u32>> for LoadOp<u32> {
+    fn into_wgpu(self) -> wgpu::LoadOp<u32> {
+        match self {
+            LoadOp::Load => wgpu::LoadOp::Load,
+            LoadOp::Clear(stencil) => wgpu::LoadOp::Clear(stencil),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/khora-lanes/Cargo.toml
+++ b/crates/khora-lanes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khora-lanes"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Hot-path execution pipelines for performance-critical operations"
 

--- a/crates/khora-lanes/src/render_lane/forward_plus_lane.rs
+++ b/crates/khora-lanes/src/render_lane/forward_plus_lane.rs
@@ -54,7 +54,7 @@ use khora_core::{
             buffer::BufferId,
             command::{
                 ComputePassDescriptor, LoadOp, Operations, RenderPassColorAttachment,
-                RenderPassDescriptor, StoreOp,
+                RenderPassDepthStencilAttachment, RenderPassDescriptor, StoreOp,
             },
             PrimitiveTopology,
         },
@@ -337,6 +337,16 @@ impl RenderLane for ForwardPlusLane {
         let render_pass_desc = RenderPassDescriptor {
             label: Some("Forward+ Render Pass"),
             color_attachments: &[color_attachment],
+            depth_stencil_attachment: render_ctx.depth_target.map(|depth_view| {
+                RenderPassDepthStencilAttachment {
+                    view: depth_view,
+                    depth_ops: Some(Operations {
+                        load: LoadOp::Clear(1.0),
+                        store: StoreOp::Store,
+                    }),
+                    stencil_ops: None,
+                }
+            }),
         };
 
         let mut render_pass = encoder.begin_render_pass(&render_pass_desc);

--- a/crates/khora-lanes/src/render_lane/lit_forward_lane.rs
+++ b/crates/khora-lanes/src/render_lane/lit_forward_lane.rs
@@ -32,7 +32,8 @@ use khora_core::{
     renderer::{
         api::{
             command::{
-                LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor, StoreOp,
+                LoadOp, Operations, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
+                RenderPassDescriptor, StoreOp,
             },
             PrimitiveTopology,
         },
@@ -229,6 +230,16 @@ impl RenderLane for LitForwardLane {
         let render_pass_desc = RenderPassDescriptor {
             label: Some("Lit Forward Pass"),
             color_attachments: &[color_attachment],
+            depth_stencil_attachment: render_ctx.depth_target.map(|depth_view| {
+                RenderPassDepthStencilAttachment {
+                    view: depth_view,
+                    depth_ops: Some(Operations {
+                        load: LoadOp::Clear(1.0),
+                        store: StoreOp::Store,
+                    }),
+                    stencil_ops: None,
+                }
+            }),
         };
 
         // Begin the render pass

--- a/crates/khora-lanes/src/render_lane/simple_unlit_lane.rs
+++ b/crates/khora-lanes/src/render_lane/simple_unlit_lane.rs
@@ -34,7 +34,8 @@ use khora_core::{
     renderer::{
         api::{
             command::{
-                LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor, StoreOp,
+                LoadOp, Operations, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
+                RenderPassDescriptor, StoreOp,
             },
             PrimitiveTopology,
         },
@@ -127,6 +128,16 @@ impl RenderLane for SimpleUnlitLane {
         let render_pass_desc = RenderPassDescriptor {
             label: Some("Simple Unlit Pass"),
             color_attachments: &[color_attachment],
+            depth_stencil_attachment: render_ctx.depth_target.map(|depth_view| {
+                RenderPassDepthStencilAttachment {
+                    view: depth_view,
+                    depth_ops: Some(Operations {
+                        load: LoadOp::Clear(1.0),
+                        store: StoreOp::Store,
+                    }),
+                    stencil_ops: None,
+                }
+            }),
         };
 
         // Begin the render pass

--- a/crates/khora-sdk/src/lib.rs
+++ b/crates/khora-sdk/src/lib.rs
@@ -39,10 +39,11 @@ pub mod prelude {
     pub use khora_core::asset::{AssetMetadata, AssetSource, AssetUUID};
     pub use khora_core::renderer::{
         BufferDescriptor, BufferId, BufferUsage, ColorTargetStateDescriptor, ColorWrites,
-        IndexFormat, MultisampleStateDescriptor, PipelineLayoutDescriptor, RenderObject,
+        CompareFunction, DepthBiasState, DepthStencilStateDescriptor, IndexFormat,
+        MultisampleStateDescriptor, PipelineLayoutDescriptor, RenderObject,
         RenderPipelineDescriptor, RenderPipelineId, SampleCount, ShaderModuleDescriptor,
-        ShaderModuleId, ShaderSourceData, ShaderStage, VertexAttributeDescriptor,
-        VertexBufferLayoutDescriptor, VertexFormat, VertexStepMode,
+        ShaderModuleId, ShaderSourceData, ShaderStage, StencilFaceState, TextureFormat,
+        VertexAttributeDescriptor, VertexBufferLayoutDescriptor, VertexFormat, VertexStepMode,
     };
     pub use khora_data::allocators::SaaTrackingAllocator;
 

--- a/docs/src/09_roadmap_and_issues.md
+++ b/docs/src/09_roadmap_and_issues.md
@@ -16,7 +16,6 @@ This document outlines the phased development plan for Khora. It integrates all 
 **Goal:** Build out the necessary features to represent and interact with a game world, starting with the implementation of our revolutionary ECS.
 
 #### [Rendering Capabilities, Physics, Animation, AI & Strategy Exploration]
-- #49 [Feature] Implement Depth Buffering
 - #50 [Research] Explore Alternative Rendering Paths/Strategies (e.g., Forward vs Deferred concept)
 - #100 [Feature] Implement Basic Physics System (Integration & Collision Detection) (Depends on #40)
 - #161 [Feature] Define and Implement Core PhysicsLanes (Broadphase, Solver)
@@ -196,3 +195,4 @@ This document outlines the phased development plan for Khora. It integrates all 
 - #47 [Feature] Implement Material System
 - #48 [Feature] Implement Basic Lighting Models (Track shader complexity/perf)
 - #160 [Feature] Implement Forward+ Lighting RenderLane
+- #49 [Feature] Implement Depth Buffering

--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -139,7 +139,16 @@ impl Application for SandboxApp {
             fragment_entry_point: Some("fs_main".into()),
             vertex_buffers_layout: Cow::Borrowed(&[Vertex::get_buffer_layout()]),
             primitive_state: Default::default(),
-            depth_stencil_state: None,
+            depth_stencil_state: Some(DepthStencilStateDescriptor {
+                format: TextureFormat::Depth32Float,
+                depth_write_enabled: true,
+                depth_compare: CompareFunction::Less,
+                stencil_front: StencilFaceState::default(),
+                stencil_back: StencilFaceState::default(),
+                stencil_read_mask: 0xFF,
+                stencil_write_mask: 0xFF,
+                bias: DepthBiasState::default(),
+            }),
             color_target_states: Cow::Borrowed(&[ColorTargetStateDescriptor {
                 format: surface_format,
                 blend: None,


### PR DESCRIPTION
## Description

Implements depth buffering (Z-buffering) to ensure correct occlusion of objects based on their distance from the camera. This is a foundational rendering feature that was missing from the engine.

**Changes include:**
- Core API extensions in `khora-core` for depth/stencil attachments ([RenderPassDepthStencilAttachment](cci:2://file:///d:/Dev/KhoraEngine/crates/khora-core/src/renderer/api/command.rs:72:0-83:1), extended [RenderPassDescriptor](cci:2://file:///d:/Dev/KhoraEngine/crates/khora-core/src/renderer/api/command.rs:90:0-98:1) and [RenderContext](cci:2://file:///d:/Dev/KhoraEngine/crates/khora-core/src/renderer/api/context.rs:19:0-26:1))
- WGPU backend implementation in `khora-infra` for depth texture creation, management, and lifecycle (resize handling)
- Render lane updates in `khora-lanes` to support depth attachments in all three render lanes
- Sandbox example updated to configure the pipeline with `DepthStencilStateDescriptor`

*   Implements #49

## Type of change

Please check the boxes that apply or delete options that are not relevant.

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation update**
- [ ] **Refactoring / Performance improvements**
- [ ] **Build system / CI improvements**
- [ ] **Other** (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce, if applicable. Please also list any relevant details for your test configuration.

- [x] New unit tests added/updated for the changes.
- [x] All existing unit tests pass with these changes.
- [x] Manual testing performed as described below:
    *   Step 1: Run `cargo run -p sandbox`
    *   Step 2: Observe initialization logs confirming depth texture creation
    *   Step 3: Verify no WGPU validation errors during rendering
    *   Observed result: Depth texture created correctly (1024x768, Depth32Float), no validation errors, triangle renders as expected.

**Test Configuration (if relevant for manual testing)**:
*   KhoraEngine Version/Commit: khora-core 0.2.2, khora-infra 0.2.2, khora-lanes 0.1.2
*   OS: Windows
*   Graphics Backend: Vulkan (AMD Radeon RX 6800 XT)

## Checklist:

Before submitting your pull request, please make sure you have completed the following:

- [x] I have read the [CONTRIBUTING.md](https://github.com/eraflo/KhoraEngine/blob/main/CONTRIBUTING.md) file (if it exists and is relevant for this type of contribution).
- [x] My code follows the style guidelines of this project. I have run `cargo fmt --all -- --check` locally and it passes.
- [x] My code has been linted with `cargo clippy --workspace --all-targets --all-features -- -D warnings` and there are no new clippy warnings.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas or for complex logic.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new compiler warnings.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] New and existing unit tests pass locally with my changes (`cargo test --workspace --all-targets --all-features`).
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable).

## Screenshots (if applicable)

N/A - The depth buffer itself is not directly visible, but its effect will be demonstrated when multiple overlapping objects are rendered.

## Further comments or questions for the reviewer

**Key implementation notes:**
- Uses `Depth32Float` format for maximum precision
- Depth buffer is cleared to `1.0` (far plane) at the start of each render pass
- Depth texture is automatically recreated on window resize (both immediate and deferred paths)
- The [RenderContext](cci:2://file:///d:/Dev/KhoraEngine/crates/khora-core/src/renderer/api/context.rs:19:0-26:1) now carries an optional `depth_target` for render lanes to use

**Files changed:**
- `khora-core`: [command.rs](cci:7://file:///d:/Dev/KhoraEngine/crates/khora-core/src/renderer/api/command.rs:0:0-0:0), [context.rs](cci:7://file:///d:/Dev/KhoraEngine/crates/khora-core/src/renderer/api/context.rs:0:0-0:0), `mod.rs`
- `khora-infra`: `conversions.rs`, [command.rs](cci:7://file:///d:/Dev/KhoraEngine/crates/khora-core/src/renderer/api/command.rs:0:0-0:0), [system.rs](cci:7://file:///d:/Dev/KhoraEngine/crates/khora-infra/src/graphics/wgpu/system.rs:0:0-0:0)
- `khora-lanes`: [simple_unlit_lane.rs](cci:7://file:///d:/Dev/KhoraEngine/crates/khora-lanes/src/render_lane/simple_unlit_lane.rs:0:0-0:0), [lit_forward_lane.rs](cci:7://file:///d:/Dev/KhoraEngine/crates/khora-lanes/src/render_lane/lit_forward_lane.rs:0:0-0:0), [forward_plus_lane.rs](cci:7://file:///d:/Dev/KhoraEngine/crates/khora-lanes/src/render_lane/forward_plus_lane.rs:0:0-0:0)
- `sandbox`: [main.rs](cci:7://file:///d:/Dev/KhoraEngine/examples/sandbox/src/main.rs:0:0-0:0)
- `docs`: [09_roadmap_and_issues.md](cci:7://file:///d:/Dev/KhoraEngine/docs/src/09_roadmap_and_issues.md:0:0-0:0) (moved #49 to closed issues)